### PR TITLE
Feature handle crypt secret

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -449,12 +449,7 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 	rep := &csi.CreateVolumeResponse{}
 
 	// Resolve provision secret credentials.
-	provisionerSecretsRef, err := getSecretReferenceMany(p.client, provisionerSecretParams, options.StorageClass.Parameters, pvName, &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      options.PVC.Name,
-			Namespace: options.PVC.Namespace,
-		},
-	})
+	provisionerSecretsRef, err := getSecretReferenceMany(p.client, provisionerSecretParams, options.StorageClass.Parameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -70,6 +70,9 @@ const (
 	prefixedProvisionerSecretNameKey      = csiParameterPrefix + "provisioner-secret-name"
 	prefixedProvisionerSecretNamespaceKey = csiParameterPrefix + "provisioner-secret-namespace"
 
+	prefixedCryptSecretNameKey      = csiParameterPrefix + "crypt-secret-name"
+	prefixedCryptSecretNamespaceKey = csiParameterPrefix + "crypt-secret-namespace"
+
 	prefixedControllerPublishSecretNameKey      = csiParameterPrefix + "controller-publish-secret-name"
 	prefixedControllerPublishSecretNamespaceKey = csiParameterPrefix + "controller-publish-secret-namespace"
 
@@ -120,6 +123,12 @@ var (
 		deprecatedSecretNamespaceKey: provisionerSecretNamespaceKey,
 		secretNameKey:                prefixedProvisionerSecretNameKey,
 		secretNamespaceKey:           prefixedProvisionerSecretNamespaceKey,
+	}
+
+	cryptSecretParams = secretParamsMap{
+		name:               "Crypt",
+		secretNameKey:      prefixedCryptSecretNameKey,
+		secretNamespaceKey: prefixedCryptSecretNamespaceKey,
 	}
 
 	nodePublishSecretParams = secretParamsMap{
@@ -444,8 +453,6 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 		req.AccessibilityRequirements = requirements
 	}
 
-	klog.V(5).Infof("CreateVolumeRequest %+v", req)
-
 	rep := &csi.CreateVolumeResponse{}
 
 	// Resolve provision secret credentials.
@@ -453,18 +460,32 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 	if err != nil {
 		return nil, err
 	}
+
+	// Resolve crypt secret credentials.
+	cryptSecretRef, err := getSecretReference(cryptSecretParams, options.StorageClass.Parameters, pvName, options.PVC)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add user's crypt key to the secrets of the request
+	provisionerSecretsRef = append(provisionerSecretsRef, cryptSecretRef)
+
 	provisionerCredentials, err := getCredentialsMany(p.client, provisionerSecretsRef)
 	if err != nil {
 		return nil, err
 	}
 	req.Secrets = provisionerCredentials
 
+	klog.Infof("CreateVolumeRequest %+v", req)
+
 	// Resolve controller publish, node stage, node publish secret references
 	controllerPublishSecretRef, err := getSecretReference(controllerPublishSecretParams, options.StorageClass.Parameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}
-	nodeStageSecretRef, err := getSecretReference(nodeStageSecretParams, options.StorageClass.Parameters, pvName, options.PVC)
+	// To mount an encrypted volume, we need the user's crypt key
+	// An alternative could be to explicitly specify a StorageClass annotation
+	nodeStageSecretRef, err := getSecretReference(cryptSecretParams, options.StorageClass.Parameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}
@@ -593,6 +614,8 @@ func removePrefixedParameters(param map[string]string) (map[string]string, error
 			case prefixedFsTypeKey:
 			case prefixedProvisionerSecretNameKey:
 			case prefixedProvisionerSecretNamespaceKey:
+			case prefixedCryptSecretNameKey:
+			case prefixedCryptSecretNamespaceKey:
 			case prefixedControllerPublishSecretNameKey:
 			case prefixedControllerPublishSecretNamespaceKey:
 			case prefixedNodeStageSecretNameKey:
@@ -858,6 +881,9 @@ func getSecretReferenceMany(k8s kubernetes.Interface, secretParams secretParamsM
 				nameParams["pvc.annotations['"+k+"']"] = v
 			}
 		}
+		// The resolved Secret name might contain a glob "*" that matches multiple
+		// resources. The admin can intentionally set it so that multiple refs to
+		// Secrets are returned by this function.
 		resolvedName, err := resolveTemplate(name, nameParams)
 		if err != nil {
 			klog.Warningf("could not resolve value %q: %v", name, err)
@@ -944,6 +970,10 @@ func getSecretReference(secretParams secretParamsMap, storageClassParams map[str
 }
 
 func resolveTemplate(template string, params map[string]string) (string, error) {
+	if !strings.Contains(template, "$") {
+		// Do not attempt to format a string that is not templated
+		return template, nil
+	}
 	missingParams := sets.NewString()
 	resolved := os.Expand(template, func(k string) string {
 		v, ok := params[k]


### PR DESCRIPTION
This patch makes the csi-provisioner aware of volume encryption, i.e., extends it to provision and restore PVCs using user-provided encryption keys.

The encryption key for each volume lives in a Kubernetes Secret that is created by the user in the same namespace with the respective PVC. Plus, the Secret name has the following convention/template so that it can be retrieved by the CSI sidecar:

`"rok-crypt-${pvc.name}"`

Since the volume encryption key is needed during both the provisioning and the node staging phases, refactor how the CSI provisioner sidecar decides which Secrets to retrieve from the Kubernetes API server in each case, by taking the StorageClass parameters into account.